### PR TITLE
Use grub2-mkrescue, if grub-mkrescue cannot be found in path.

### DIFF
--- a/support/scripts/cargos-iso.sh
+++ b/support/scripts/cargos-iso.sh
@@ -30,7 +30,8 @@ menuentry 'CargOS-${_version} with serial console on ttyS0' {
 }
 EOF
 
-		grub-mkrescue -o cargos${_rel}${_c}-${_version}.iso ${_tmp}
+		GMR=`which grub-mkrescue 2>/dev/null`; test -n "${GMR}" || GMR=`which grub2-mkrescue 2>/dev/null`
+		${GMR} -o cargos${_rel}${_c}-${_version}.iso ${_tmp}
 		qemu-img convert -O qcow2 cargos${_rel}${_c}-${_version}.iso cargos${_rel}${_c}-${_version}.qcow2
 
 		rm -rf ${_tmp}/* && rmdir ${_tmp}

--- a/system/skeleton-cargos/etc/rc.bootstrap
+++ b/system/skeleton-cargos/etc/rc.bootstrap
@@ -406,11 +406,15 @@ prompt_localboot() {
 	dialog --backtitle "${TITLE_PREFIX} - Boot from local disk(s)" \
 		--title "Support boot from local disk(s)?" \
 		--yesno "${_message}" 9 70
-	[ $? -ne 0 ] && return 0
+	[ $? -ne 0 ] && return 1
+    return 0
+}
 
+do_localboot() {
+    local _use_dialog="$1"
 	local _version=$(cat /etc/cargos-release)
 
-	cat << EOF > /tmp/grub.cfg
+	/bin/cat << EOF > /tmp/grub.cfg
 set menu_color_normal=cyan/blue
 set menu_color_highlight=white/blue
 set timeout=10
@@ -455,6 +459,16 @@ EOF
 		_cmds[$_c_cnt]="umount /boot"
 	done
 
+    local _progressbar_cmd='/bin/cat > /dev/null'
+    local _error_dialog='echo "Failed to install boot image(s)!!!"  >> ${_install_log}'
+    if [ ${_use_dialog} = 'yes' ] ; then
+	    _progressbar_cmd='dialog --backtitle "${TITLE_PREFIX} - Boot from local disk(s)" 
+		    --title "Installing grub and current CargOS release on all disks." 
+		    --gauge "Please wait..." 10 80'
+        _error_dialog='dialog --backtitle "${TITLE_PREFIX} - Boot from local disk(s)" 
+			--title "CargOS Setup Utility" 
+			--msgbox "Failed to install boot image(s)!!!" 7 75'
+    fi
 	n=${#_cmds[*]}; 
 	i=0
 	for f in "${_cmds[@]}"
@@ -462,16 +476,11 @@ EOF
 		local _pct=$(( 100*(++i)/n ))
 		echo ${_pct}
 		eval $f >> ${_install_log} 2>&1
-	done | \
-	dialog --backtitle "${TITLE_PREFIX} - Boot from local disk(s)" \
-		--title "Installing grub and current CargOS release on each disk's boot partition" \
-		--gauge "Please wait..." 10 80
+	done | eval ${_progressbar_cmd}
 
 	test -s /tmp/bzImage-${_version} -a -s /tmp/rootfs.squashfs-noinst-${_version} || \
-		dialog --backtitle "${TITLE_PREFIX} - Boot from local disk(s)" \
-			--title "CargOS Setup Utility" \
-			--msgbox "Failed to install boot image(s)!!!" 7 75
-			
+        eval ${_error_dialog}
+
 	rm -f /tmp/bzImage-${_version} /tmp/rootfs.squashfs-noinst-${_version} /tmp/grub.cfg
 }
 
@@ -684,6 +693,7 @@ while [ /usr/bin/true ]; do
 		_hostname=$(ip link show ${_snic} | grep link | cut -d ' ' -f6 | sed 's/:/-/g')
 		create_persistent
 		create_network_config
+        do_localboot no
 		handle_cloud
 	else
 		prompt_welcome
@@ -696,7 +706,7 @@ while [ /usr/bin/true ]; do
 		while true ; do change_root_password && break ; done
 		set_timezone
 		save_kmap
-		prompt_localboot
+		prompt_localboot && do_localboot yes || :
 	fi
 
 	/etc/rc.d/network stop >/dev/null 2>&1


### PR DESCRIPTION
Make build succeed on systems where grub-mkrescue is actually named grub2-mkrescue.
e.g. this is true for Fedora.

In addition, you probably want to mention grub2-tools in the list of required packages for building.
