### PR TITLE
Execute cloud-init runcmd as very last step of the startup

### DIFF
--- a/system/skeleton-cargos/etc/rc
+++ b/system/skeleton-cargos/etc/rc
@@ -236,6 +236,15 @@ rc_real_work()
 		print_rc_metadata "cmd-status:$_rc_elem:$?"
 	done
 
+    # If cloud-init has created a runcmd script, run it
+    if [ -s /tmp/cloud-init-runcmd.sh ]; then
+	    print_rc_metadata "cmd-name:cloud-init-runcmd"
+        bash /tmp/cloud-init-runcmd.sh > /var/log/cloud-init-runcmd.log 2>&1
+        print_rc_metadata "cmd-status:cloud-init-runcmd:$?"
+        # This should only run on first boot, so delete it
+        rm -f /tmp/cloud-init-runcmd.sh
+    fi
+
 	print_rc_metadata "end:$(date)"
 	exit 0
 )

--- a/system/skeleton-cargos/etc/rc.bootstrap
+++ b/system/skeleton-cargos/etc/rc.bootstrap
@@ -6,9 +6,9 @@ export PATH
 export TERM=xterm-color
 
 network_tmp=$(mktemp 2>/dev/null)
-runcmd_tmp=$(mktemp 2>/dev/null)
+runcmd_tmp=/tmp/cloud-init-runcmd.sh
  
-trap "rm -f $network_tmp $runcmd_tmp" 0 1 2 5 15
+trap "rm -f $network_tmp" 0 1 2 5 15
 
 TITLE_PREFIX="CargOS Setup"
 _sdisks=""
@@ -966,11 +966,6 @@ while [ /usr/bin/true ]; do
 		prompt_localboot && do_localboot yes || :
 	fi
 
-	if [ -s ${runcmd_tmp} ] ; then
-		echo "executing the following runcmd commands:" >> ${_install_log}
-		cat ${runcmd_tmp} >> ${_install_log}
-		source ${runcmd_tmp} >> ${_install_log} 2>&1
-	fi
 	/etc/rc.d/network stop >/dev/null 2>&1
 
 	is_cloud || prompt_end


### PR DESCRIPTION
Fixed a problem with cgroups not yet mounted when execuding cloud-init runcmd commands.
